### PR TITLE
Add config path argument

### DIFF
--- a/ews_calendar_sync.py
+++ b/ews_calendar_sync.py
@@ -17,7 +17,7 @@
 
 import datetime
 import logging
-
+import argparse
 import toml
 from exchangelib import Credentials, Configuration, Account, DELEGATE, IMPERSONATION, CalendarItem
 import caldav
@@ -25,7 +25,11 @@ import icalendar
 
 logger = logging.getLogger(__name__)
 
-with open('config.toml', encoding='utf-8') as f:
+parser = argparse.ArgumentParser(description='Read a TOML configuration file.')
+parser.add_argument('--config', default='config.toml', help='Path of the TOML configuration file')
+args = parser.parse_args()
+
+with open(args.config, encoding='utf-8') as f:
     config = toml.load(f)
 
 logging.basicConfig(level=config['misc']['loglevel'])

--- a/ews_calendar_sync.py
+++ b/ews_calendar_sync.py
@@ -25,7 +25,7 @@ import icalendar
 
 logger = logging.getLogger(__name__)
 
-parser = argparse.ArgumentParser(description='Read a TOML configuration file.')
+parser = argparse.ArgumentParser(description='Incrementally synchronizes a Microsoft Exchange calendar to a CalDAV server.')
 parser.add_argument('--config', default='config.toml', help='Path of the TOML configuration file')
 args = parser.parse_args()
 


### PR DESCRIPTION
This enables placing the config file in a different directory than the .py script and also syncing multiple accounts in parallel.